### PR TITLE
Repro test case for pnpm + docker failing snapshot

### DIFF
--- a/pnpm-testing/Dockerfile.pnpm
+++ b/pnpm-testing/Dockerfile.pnpm
@@ -1,0 +1,50 @@
+FROM node:22-slim
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+# Install essential packages
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    ca-certificates \
+    iproute2 \
+    iptables \
+    git \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker from official Docker repository
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update && \
+    apt-get install -y \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pnpm globally
+RUN npm install -g pnpm@latest
+
+# Create working directory
+WORKDIR /workspace
+
+# Clone Slidev repository (medium-sized pnpm monorepo)
+RUN git clone --depth 1 https://github.com/slidevjs/slidev.git /workspace/slidev
+
+# Pre-configure pnpm to use a specific store location
+RUN pnpm config set store-dir /root/.pnpm-store
+
+# Copy the docker startup script
+COPY start-dockerd.sh /start-dockerd.sh
+RUN chmod +x /start-dockerd.sh

--- a/pnpm-testing/README.md
+++ b/pnpm-testing/README.md
@@ -1,0 +1,40 @@
+# PNPM Snapshotting Bug Reproduction
+
+This test reproduces a Modal filesystem snapshotting failure that occurs when using pnpm to install packages in a Docker-in-gvisor environment.
+
+## Running the Test
+
+```bash
+uv run pnpm-testing/modal_pnpm_snapshot.py
+```
+
+
+## Test Setup
+
+- **Repository**: Slidev (https://github.com/slidevjs/slidev)
+  - Medium-sized pnpm monorepo
+  - ~50-100 direct dependencies
+  - Presentation framework built with Vue
+  
+- **Environment**: 
+  - Modal Sandbox with `enable_docker_in_gvisor: True`
+  - Docker daemon running inside the sandbox
+  - Node.js 22 with pnpm latest
+
+## Files
+
+- `modal_pnpm_snapshot.py` - Main test script that:
+  1. Creates a Modal sandbox with Docker-in-gvisor
+  2. Starts Docker daemon
+  3. Runs `pnpm install` in the Slidev repository
+  4. Attempts to create a filesystem snapshot
+  5. Reports success/failure with timing metrics
+
+- `Dockerfile.pnpm` - Docker image that includes:
+  - Node.js 22
+  - Docker and docker-compose
+  - pnpm package manager
+  - Pre-cloned Slidev repository
+  - Network utilities (iproute2, iptables)
+
+- `start-dockerd.sh` - Script to initialize Docker daemon with proper networking

--- a/pnpm-testing/modal_pnpm_snapshot.py
+++ b/pnpm-testing/modal_pnpm_snapshot.py
@@ -1,0 +1,138 @@
+import os
+import time
+import modal
+
+# Use the 2025.06 Modal Image Builder
+os.environ["MODAL_IMAGE_BUILDER_VERSION"] = "2025.06"
+
+# Build the Docker image with pnpm and Slidev repository
+dockerfile_image = modal.Image.from_dockerfile("./pnpm-testing/Dockerfile.pnpm")
+
+
+def main():
+    print("=" * 60)
+    print("PNPM Snapshotting Bug Reproduction Test")
+    print("=" * 60)
+
+    print("\n1. Looking up/creating Modal app...")
+    app = modal.App.lookup("pnpm-snapshot-test", create_if_missing=True)
+
+    print("2. Creating sandbox with Docker-in-gvisor enabled...")
+    start_time = time.time()
+
+    with modal.enable_output():
+        sb = modal.Sandbox.create(
+            "/start-dockerd.sh",
+            timeout=60 * 60,  # 1 hour timeout
+            app=app,
+            image=dockerfile_image,
+            experimental_options={"enable_docker_in_gvisor": True},
+        )
+
+    print(f"   Sandbox created in {time.time() - start_time:.2f}s")
+
+    # Wait for Docker daemon to be ready
+    print("\n3. Waiting for Docker daemon to initialize...")
+    time.sleep(5)
+
+    # Verify Docker is running
+    print("4. Verifying Docker daemon status...")
+    p = sb.exec("docker", "version")
+    docker_version = p.stdout.read()
+    p.wait()
+    print(f"   Docker status: {'Running' if p.returncode == 0 else 'Failed'}")
+    if p.returncode != 0:
+        print(f"   Error: {p.stderr.read()}")
+        sb.terminate()
+        return
+
+    # Check the Slidev repo structure
+    print("\n5. Checking Slidev repository structure...")
+    p = sb.exec("ls", "-la", "/workspace/slidev")
+    print("   Repository contents:")
+    for line in p.stdout:
+        print(f"   {line}", end="")
+
+    # Count packages before install
+    print("\n6. Analyzing package.json files...")
+    p = sb.exec("find", "/workspace/slidev", "-name", "package.json", "-type", "f")
+    package_files = list(p.stdout)
+    print(f"   Found {len(package_files)} package.json files")
+
+    # Run pnpm install
+    print("\n7. Running pnpm install...")
+    install_start = time.time()
+    p = sb.exec("bash", "-c", "cd /workspace/slidev && pnpm install")
+
+    # Stream output
+    line_count = 0
+    for line in p.stdout:
+        if line_count < 20:  # Show first 20 lines
+            print(f"   {line}", end="")
+        line_count += 1
+
+    p.wait()
+    install_duration = time.time() - install_start
+
+    if p.returncode != 0:
+        print(f"   ERROR: pnpm install failed with code {p.returncode}")
+        print(f"   stderr: {p.stderr.read()}")
+    else:
+        print(f"   pnpm install completed successfully in {install_duration:.2f}s")
+        print(f"   Total output lines: {line_count}")
+
+    # Check node_modules size
+    print("\n8. Checking installed packages...")
+    p = sb.exec(
+        "bash",
+        "-c",
+        "find /workspace/slidev -name node_modules -type d | xargs du -sh 2>/dev/null | tail -5",
+    )
+    for line in p.stdout:
+        print(f"   {line}", end="")
+
+    # Count total packages installed
+    p = sb.exec(
+        "bash",
+        "-c",
+        "find /workspace/slidev -path '*/node_modules/*' -name package.json | wc -l",
+    )
+    package_count = p.stdout.read().strip()
+    print(f"   Total packages installed: {package_count}")
+
+    # Attempt to create a snapshot
+    print("\n9. Attempting to create filesystem snapshot...")
+    snapshot_start = time.time()
+
+    try:
+        image = sb.snapshot_filesystem()
+        snapshot_duration = time.time() - snapshot_start
+        print(f"   SUCCESS: Snapshot created in {snapshot_duration:.2f}s")
+        print(f"   Snapshot image: {image}")
+    except Exception as e:
+        snapshot_duration = time.time() - snapshot_start
+        print(f"   FAILED: Snapshot failed after {snapshot_duration:.2f}s")
+        print(f"   Error: {str(e)}")
+        print(f"   Error type: {type(e).__name__}")
+
+    # Clean up
+    print("\n10. Terminating sandbox...")
+    sb.terminate()
+    print("    Sandbox terminated")
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("TEST SUMMARY")
+    print("=" * 60)
+    print("Repository: Slidev (presentation framework)")
+    print("Package manager: pnpm")
+    print(f"Packages installed: {package_count}")
+    print(f"Install duration: {install_duration:.2f}s")
+    print(f"Snapshot attempt: {'SUCCESS' if 'image' in locals() else 'FAILED'}")
+    if "image" in locals():
+        print(f"Snapshot duration: {snapshot_duration:.2f}s")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/pnpm-testing/start-dockerd.sh
+++ b/pnpm-testing/start-dockerd.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -xe -o pipefail
+
+dev=$(ip route show default | awk '/default/ {print $5}')
+if [ -z "$dev" ]; then
+    echo "Error: No default device found."
+    ip route show
+    exit 1
+else
+    echo "Default device: $dev"
+fi
+addr=$(ip addr show dev "$dev" | grep -w inet | awk '{print $2}' | cut -d/ -f1)
+if [ -z "$addr" ]; then
+    echo "Error: No IP address found for device $dev."
+    ip addr show dev "$dev"
+    exit 1
+else
+    echo "IP address for $dev: $addr"
+fi
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
+iptables-legacy -t nat -A POSTROUTING -o "$dev" -j SNAT --to-source "$addr" -p tcp
+iptables-legacy -t nat -A POSTROUTING -o "$dev" -j SNAT --to-source "$addr" -p udp
+
+exec /usr/bin/dockerd --iptables=false --ip6tables=false -D


### PR DESCRIPTION
This adds a test script to reproduce a snapshotting failure when using `docker-in-gvisor` flag + pnpm install.

We leverage an OSS repo that has a bunch of pnpm dependencies to match behavior we see in our private repo.

Run with:

```
uv run pnpm-testing/modal_pnpm_snapshot.py
```